### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: python
+before_script:
+- pip install tox
+# test script
+script:  tox
+notifications:
+  on_success: change
+  on_failure: always
+matrix:
+  include:
+    - python: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ deps =
     flake8 >= 3.2.1
     attrs
 whitelist_externals =
-    cd
     git
 
 [testenv:tests]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+minversion=2.3.1
+envlist = tests,typeshed
+
+[testenv]
+deps =
+    flake8 >= 3.2.1
+    attrs
+whitelist_externals =
+    cd
+    git
+
+[testenv:tests]
+commands =
+    python setup.py test
+
+[testenv:typeshed]
+commands =
+    pip install -U .
+    git clone https://www.github.com/python/typeshed {envtmpdir}/typeshed
+    flake8 {envtmpdir}/typeshed


### PR DESCRIPTION
I'd like to have this to make sure that future changes to this repo don't fail on current typeshed.

I mostly went off flake8's own configuration: https://gitlab.com/pycqa/flake8/tree/master. It passes at https://travis-ci.org/JelleZijlstra/flake8-pyi, but you'll have to enable Travis yourself on this repo if you merge this.