### PR TITLE
require python 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py35.py36
+python-tag = py36

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 import sys
 
 
-assert sys.version_info >= (3, 5, 0), "flake8-pyi requires Python 3.5+"
+assert sys.version_info >= (3, 6, 0), "flake8-pyi requires Python 3.6+"
 
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -45,7 +45,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Quality Assurance',


### PR DESCRIPTION
Currently flake8-pyi only works on 3.6 because I put a variable annotation somewhere in pyi.py by accident. That's easy to fix, but I think we should require 3.6 only anyway, because several typeshed stubs now also use PEP 526-style annotations.

I tried to work around the problem by hacking flake8 to use typed-ast to parse stubs, but that doesn't really work because flake8 gets confused when it gets a typed_ast.ast3.Store instead of an ast.Store. I suppose we could translate the typed-ast AST to an ast AST, but life is too short for that.

Related: python/mypy#3398.