### PR TITLE
Raise an error if a body of an empty class starts with "pass"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,8 @@ currently emitted:
 * Y011: All default values for typed function arguments must be "...". Type
   checkers ignore the default value, so the default value is not useful
   information in a stub file.
+* Y012: Class body must not contain "pass".
+* Y013: Non-empty class body must not contain "...".
 
 The following warnings are disabled by default:
 

--- a/pyi.py
+++ b/pyi.py
@@ -247,6 +247,26 @@ class PyiVisitor(ast.NodeVisitor):
         else:
             self.error(node, Y007)
 
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.generic_visit(node)
+
+        # empty class body should contain "..." not "pass"
+        if len(node.body) == 1:
+            statement = node.body[0]
+            if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Ellipsis):
+                return
+            elif isinstance(statement, ast.Pass):
+                self.error(statement, Y009)
+                return
+
+        for i, statement in enumerate(node.body):
+            # "pass" should not used in class body
+            if isinstance(statement, ast.Pass):
+                self.error(statement, Y012)
+            # "..." should not be used in non-empty class body
+            elif isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Ellipsis):
+                self.error(statement, Y013)
+
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self.generic_visit(node)
 
@@ -367,6 +387,8 @@ Y008 = 'Y008 Unrecognized platform "{platform}"'
 Y009 = 'Y009 Empty body should contain "...", not "pass"'
 Y010 = 'Y010 Function body must contain only "..."'
 Y011 = 'Y011 Default values for typed arguments must be "..."'
+Y012 = 'Y012 Class body must not contain "pass"'
+Y013 = 'Y013 Non-empty class body must not contain "..."'
 Y090 = 'Y090 Use explicit attributes instead of assignments in __init__'
 
 DISABLED_BY_DEFAULT = [Y090]

--- a/tests/emptyclasses.pyi
+++ b/tests/emptyclasses.pyi
@@ -1,0 +1,21 @@
+class EmptyClass:
+    ...
+
+class PassingEmptyClass:
+    pass  # Y009
+
+class PassingNonEmptyClass:
+    x: int
+    pass  # Y011
+
+class PassingNonEmptyClass2:
+    pass  # Y011
+    x: int
+
+class EllipsisNonEmptyClass:
+    x: int
+    ...  # Y012
+
+class EllipsisNonEmptyClass2:
+    ...  # Y012
+    x: int

--- a/tests/test_pyi.py
+++ b/tests/test_pyi.py
@@ -115,6 +115,16 @@ class PyiTestCase(unittest.TestCase):
         )
         self.checkFileOutput('comparisons.pyi', stdout_lines=stdout_lines)
 
+    def test_class_def(self) -> None:
+        stdout_lines = (
+            '5:5: Y009 Empty body should contain "...", not "pass"',
+            '9:5: Y012 Class body must not contain "pass"',
+            '12:5: Y012 Class body must not contain "pass"',
+            '17:5: Y013 Non-empty class body must not contain "..."',
+            '20:5: Y013 Non-empty class body must not contain "..."',
+        )
+        self.checkFileOutput('emptyclasses.pyi', stdout_lines=stdout_lines)
+
     def test_function_def(self) -> None:
         stdout_lines = (
             '5:5: Y009 Empty body should contain "...", not "pass"',


### PR DESCRIPTION
## Background
- I find that some empty classes in python/typeshed uses `pass` instead of `...`
https://github.com/python/typeshed/blob/b261b228ba2a29c980212d9648decde18de7b089/stdlib/2/io.pyi#L36-L40
- We already have `Y009` for disallowing use of `pass` in functions

## Proposal
Extend `Y009` to disallow use of `pass` in empty classes.