### PR TITLE
Use --stdin-display-name as filename when reading from stdin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,11 @@ Note: tests require 3.6+ due to testing variable annotations.
 Change Log
 ----------
 
+18.10.0
+~~~~~~~
+
+* use --stdin-display-name as the filename when reading from stdin
+
 18.3.1
 ~~~~~~
 

--- a/pyi.py
+++ b/pyi.py
@@ -124,7 +124,7 @@ class PyiAwareFileChecker(checker.FileChecker):
             LOG.info(
                 'Replacing FlakesChecker with PyiAwareFlakesChecker while '
                 'checking %r',
-                filename
+                filename,
             )
             plugin = dict(plugin)
             plugin['plugin'] = PyiAwareFlakesChecker

--- a/pyi.py
+++ b/pyi.py
@@ -115,11 +115,16 @@ class PyiAwareFlakesChecker(FlakesChecker):
 
 class PyiAwareFileChecker(checker.FileChecker):
     def run_check(self, plugin, **kwargs):
-        if self.filename.endswith('.pyi') and plugin['plugin'] == FlakesChecker:
+        if self.filename == '-':
+            filename = self.options.stdin_display_name
+        else:
+            filename = self.filename
+
+        if filename.endswith('.pyi') and plugin['plugin'] == FlakesChecker:
             LOG.info(
                 'Replacing FlakesChecker with PyiAwareFlakesChecker while '
                 'checking %r',
-                self.filename,
+                filename
             )
             plugin = dict(plugin)
             plugin['plugin'] = PyiAwareFlakesChecker


### PR DESCRIPTION
When reading from `stdin`, `flake8.checker.FileChecker.filename` is set to `'-'`. This means that `PyiAwareFlakesChecker` does not replace `FlakesChecker` and things like forward references will fail the linter. Passing the contents of a file to `stdin` is a common thing for vim plugins to do, so this allows `pyi` files to be properly linted in vim.