### PR TITLE
flake8 3.6.0 fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 # This is an example .flake8 config, used when developing flake8-pyi itself.
 
 [flake8]
-ignore = E302, E501, E701
+ignore = E302, E501, E701, W503
 max-line-length = 80
 max-complexity = 12
 select = B,C,E,F,W,Y,B9

--- a/pyi.py
+++ b/pyi.py
@@ -96,9 +96,9 @@ class PyiAwareFlakesChecker(FlakesChecker):
         self.pushScope(ClassScope)
         # doctest does not process doctest within a doctest
         # classes within classes are processed.
-        if (self.withDoctest and
-                not self._in_doctest() and
-                not isinstance(self.scope, FunctionScope)):
+        if (self.withDoctest
+                and not self._in_doctest()
+                and not isinstance(self.scope, FunctionScope)):
             self.deferFunction(lambda: self.handleDoctests(node))
         for stmt in node.body:
             self.handleNode(stmt, node)


### PR DESCRIPTION
Move binary operators to the front of lines (for future compatibility with black) and ignore error W503.