### PR TITLE
Add attribute value checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ currently emitted:
 * Y013: Non-empty class body must not contain "...".
 * Y014: All default values for arguments must be "...". A stronger version
   of Y011 that includes arguments without type annotations.
-* Y015: Top-level attribute must not have a default value.
-* Y016: Instance attribute must not have a default value other than "...".
+* Y015: Attribute must not have a default value other than "...".
 
 The following warnings are disabled by default:
 
@@ -84,6 +83,7 @@ The following warnings are disabled by default:
          def __init__(self, x: str) -> None: ...
 
 * Y091: Function body must not contain "raise".
+* Y092: Top-level attribute must not have a default value.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ currently emitted:
 * Y013: Non-empty class body must not contain "...".
 * Y014: All default values for arguments must be "...". A stronger version
   of Y011 that includes arguments without type annotations.
+* Y015: Top-level attribute must not have a default value.
 
 The following warnings are disabled by default:
 

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ currently emitted:
 * Y014: All default values for arguments must be "...". A stronger version
   of Y011 that includes arguments without type annotations.
 * Y015: Top-level attribute must not have a default value.
+* Y016: Instance attribute must not have a default value other than "...".
 
 The following warnings are disabled by default:
 

--- a/pyi.py
+++ b/pyi.py
@@ -152,21 +152,15 @@ class PyiVisitor(ast.NodeVisitor):
                     if not self.filename.name == "typing.pyi":
                         self.error(target, Y001)
         if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-            if self._in_class:
-                if isinstance(node.value, (ast.Num, ast.Str)):
-                    self.error(node.value, Y016)
-            else:
-                if isinstance(node.value, (ast.Num, ast.Str)):
-                    self.error(node.value, Y015)
+            if isinstance(node.value, (ast.Num, ast.Str)):
+                self.error(node.value, Y015)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if isinstance(node.target, ast.Name):
-            if self._in_class:
-                if node.value and not isinstance(node.value, ast.Ellipsis):
-                    self.error(node.value, Y016)
-            else:
-                if node.value:
-                    self.error(node.value, Y015)
+            if node.value and not isinstance(node.value, ast.Ellipsis):
+                self.error(node.value, Y015)
+            elif node.value and not self._in_class:
+                self.error(node.value, Y092)
 
     def visit_If(self, node: ast.If) -> None:
         self.generic_visit(node)
@@ -436,9 +430,9 @@ Y011 = 'Y011 Default values for typed arguments must be "..."'
 Y012 = 'Y012 Class body must not contain "pass"'
 Y013 = 'Y013 Non-empty class body must not contain "..."'
 Y014 = 'Y014 Default values for arguments must be "..."'
-Y015 = "Y015 Top-level attribute must not have a default value"
-Y016 = 'Y016 Instance attribute must not have a default value other than "..."'
+Y015 = 'Y015 Attribute must not have a default value other than "..."'
 Y090 = "Y090 Use explicit attributes instead of assignments in __init__"
 Y091 = 'Y091 Function body must not contain "raise"'
+Y092 = "Y092 Top-level attribute must not have a default value"
 
-DISABLED_BY_DEFAULT = [Y090, Y091]
+DISABLED_BY_DEFAULT = [Y090, Y091, Y092]

--- a/pyi.py
+++ b/pyi.py
@@ -151,18 +151,22 @@ class PyiVisitor(ast.NodeVisitor):
                     # avoid catching AnyStr in typing (the only library TypeVar so far)
                     if not self.filename.name == "typing.pyi":
                         self.error(target, Y001)
-        if (
-            self._in_class == 0
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-        ):
-            if isinstance(node.value, (ast.Num, ast.Str)):
-                self.error(node.value, Y015)
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            if self._in_class:
+                if isinstance(node.value, (ast.Num, ast.Str)):
+                    self.error(node.value, Y016)
+            else:
+                if isinstance(node.value, (ast.Num, ast.Str)):
+                    self.error(node.value, Y015)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        if self._in_class == 0 and isinstance(node.target, ast.Name):
-            if node.value:
-                self.error(node.value, Y015)
+        if isinstance(node.target, ast.Name):
+            if self._in_class:
+                if node.value and not isinstance(node.value, ast.Ellipsis):
+                    self.error(node.value, Y016)
+            else:
+                if node.value:
+                    self.error(node.value, Y015)
 
     def visit_If(self, node: ast.If) -> None:
         self.generic_visit(node)
@@ -433,6 +437,7 @@ Y012 = 'Y012 Class body must not contain "pass"'
 Y013 = 'Y013 Non-empty class body must not contain "..."'
 Y014 = 'Y014 Default values for arguments must be "..."'
 Y015 = "Y015 Top-level attribute must not have a default value"
+Y016 = 'Y016 Instance attribute must not have a default value other than "..."'
 Y090 = "Y090 Use explicit attributes instead of assignments in __init__"
 Y091 = 'Y091 Function body must not contain "raise"'
 

--- a/pyi.py
+++ b/pyi.py
@@ -10,7 +10,7 @@ import optparse
 from pathlib import Path
 from pyflakes.checker import PY2, ClassDefinition
 from pyflakes.checker import ModuleScope, ClassScope, FunctionScope
-from typing import Any, Iterable, NamedTuple, Optional, Type
+from typing import Any, Iterable, NamedTuple, Optional, Type, Union
 
 __version__ = "19.2.0"
 
@@ -135,12 +135,12 @@ class PyiAwareFileChecker(checker.FileChecker):
 class PyiVisitor(ast.NodeVisitor):
     filename = attr.ib(default=Path("(none)"))
     errors = attr.ib(default=attr.Factory(list))
+    _in_class = attr.ib(default=0)
 
     def visit_Assign(self, node: ast.Assign) -> None:
-        """Attempt to find assignments to type helpers (typevars and aliases), which should be
-        private.
-        """
         self.generic_visit(node)
+        # Attempt to find assignments to type helpers (typevars and aliases), which should be
+        # private.
         if (
             isinstance(node.value, ast.Call)
             and isinstance(node.value.func, ast.Name)
@@ -151,6 +151,18 @@ class PyiVisitor(ast.NodeVisitor):
                     # avoid catching AnyStr in typing (the only library TypeVar so far)
                     if not self.filename.name == "typing.pyi":
                         self.error(target, Y001)
+        if (
+            self._in_class == 0
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            if isinstance(node.value, (ast.Num, ast.Str)):
+                self.error(node.value, Y015)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if self._in_class == 0 and isinstance(node.target, ast.Name):
+            if node.value:
+                self.error(node.value, Y015)
 
     def visit_If(self, node: ast.If) -> None:
         self.generic_visit(node)
@@ -263,7 +275,9 @@ class PyiVisitor(ast.NodeVisitor):
             self.error(node, Y007)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._in_class += 1
         self.generic_visit(node)
+        self._in_class -= 1
 
         # empty class body should contain "..." not "pass"
         if len(node.body) == 1:
@@ -418,6 +432,7 @@ Y011 = 'Y011 Default values for typed arguments must be "..."'
 Y012 = 'Y012 Class body must not contain "pass"'
 Y013 = 'Y013 Non-empty class body must not contain "..."'
 Y014 = 'Y014 Default values for arguments must be "..."'
+Y015 = "Y015 Top-level attribute must not have a default value"
 Y090 = "Y090 Use explicit attributes instead of assignments in __init__"
 Y091 = 'Y091 Function body must not contain "raise"'
 

--- a/pyi.py
+++ b/pyi.py
@@ -10,7 +10,7 @@ import optparse
 from pathlib import Path
 from pyflakes.checker import PY2, ClassDefinition
 from pyflakes.checker import ModuleScope, ClassScope, FunctionScope
-from typing import Any, Iterable, NamedTuple, Optional, Type, Union
+from typing import Any, Iterable, NamedTuple, Optional, Type
 
 __version__ = "19.2.0"
 

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -9,6 +9,14 @@ field5 = 0  # type: int
 field6 = 0
 field7 = ""
 
-# Allow defaults in classes
 class Foo:
-    field: int = ...
+    # ok
+    field1: int
+    field2: int = ...
+    field3 = ...  # type: int
+
+    # not ok
+    field4: int = 0
+    field5 = 0  # type: int
+    field6 = 0
+    field7 = ""

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -1,10 +1,10 @@
 # ok
 field1: int
-field2 = ...  # type: int
+field2: int = ...  # Y092
+field3 = ...  # type: int
 
 # not ok
-field3: int = 0
-field4: int = ...
+field4: int = 0
 field5 = 0  # type: int
 field6 = 0
 field7 = ""

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -1,0 +1,14 @@
+# ok
+field1: int
+field2 = ...  # type: int
+
+# not ok
+field3: int = 0
+field4: int = ...
+field5 = 0  # type: int
+field6 = 0
+field7 = ""
+
+# Allow defaults in classes
+class Foo:
+    field: int = ...

--- a/tests/forward_refs_annassign.pyi
+++ b/tests/forward_refs_annassign.pyi
@@ -4,7 +4,7 @@ from typing import Optional, Union
 MaybeCStr = Optional[CStr]
 CStr = Union[C, str]
 __version__: str
-__author__: str = ...
+__author__: str
 
 
 def make_default_c() -> C:

--- a/tests/forward_refs_annassign.pyi
+++ b/tests/forward_refs_annassign.pyi
@@ -19,7 +19,7 @@ class D(C):
 
 
 class C:
-    other: C = None
+    other: C = ...
 
     def __init__(self) -> None:
         ...

--- a/tests/test_pyi.py
+++ b/tests/test_pyi.py
@@ -224,10 +224,12 @@ class PyiTestCase(unittest.TestCase):
         self.checkFileOutput("attribute_annotations.pyi", stdout_lines=stdout_lines)
 
     def test_attribute_values_strict(self) -> None:
-        stdout_lines = (
-            "3:15: Y092 Top-level attribute must not have a default value",
+        stdout_lines = ("3:15: Y092 Top-level attribute must not have a default value",)
+        self.checkFileOutput(
+            "attribute_annotations.pyi",
+            stdout_lines=stdout_lines,
+            extra_options=("--select=Y092",),
         )
-        self.checkFileOutput("attribute_annotations.pyi", stdout_lines=stdout_lines, extra_options=("--select=Y092",))
 
 
 if __name__ == "__main__":

--- a/tests/test_pyi.py
+++ b/tests/test_pyi.py
@@ -212,17 +212,22 @@ class PyiTestCase(unittest.TestCase):
 
     def test_attribute_values(self) -> None:
         stdout_lines = (
-            "6:15: Y015 Top-level attribute must not have a default value",
-            "7:15: Y015 Top-level attribute must not have a default value",
-            "8:10: Y015 Top-level attribute must not have a default value",
-            "9:10: Y015 Top-level attribute must not have a default value",
-            "10:10: Y015 Top-level attribute must not have a default value",
-            '19:19: Y016 Instance attribute must not have a default value other than "..."',
-            '20:14: Y016 Instance attribute must not have a default value other than "..."',
-            '21:14: Y016 Instance attribute must not have a default value other than "..."',
-            '22:14: Y016 Instance attribute must not have a default value other than "..."',
+            '7:15: Y015 Attribute must not have a default value other than "..."',
+            '8:10: Y015 Attribute must not have a default value other than "..."',
+            '9:10: Y015 Attribute must not have a default value other than "..."',
+            '10:10: Y015 Attribute must not have a default value other than "..."',
+            '19:19: Y015 Attribute must not have a default value other than "..."',
+            '20:14: Y015 Attribute must not have a default value other than "..."',
+            '21:14: Y015 Attribute must not have a default value other than "..."',
+            '22:14: Y015 Attribute must not have a default value other than "..."',
         )
         self.checkFileOutput("attribute_annotations.pyi", stdout_lines=stdout_lines)
+
+    def test_attribute_values_strict(self) -> None:
+        stdout_lines = (
+            "3:15: Y092 Top-level attribute must not have a default value",
+        )
+        self.checkFileOutput("attribute_annotations.pyi", stdout_lines=stdout_lines, extra_options=("--select=Y092",))
 
 
 if __name__ == "__main__":

--- a/tests/test_pyi.py
+++ b/tests/test_pyi.py
@@ -210,6 +210,16 @@ class PyiTestCase(unittest.TestCase):
         )
         self.checkFileOutput("defaults.pyi", stdout_lines=stdout_lines)
 
+    def test_top_level_attributes(self) -> None:
+        stdout_lines = (
+            "6:15: Y015 Top-level attribute must not have a default value",
+            "7:15: Y015 Top-level attribute must not have a default value",
+            "8:10: Y015 Top-level attribute must not have a default value",
+            "9:10: Y015 Top-level attribute must not have a default value",
+            "10:10: Y015 Top-level attribute must not have a default value",
+        )
+        self.checkFileOutput("attribute_annotations.pyi", stdout_lines=stdout_lines)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pyi.py
+++ b/tests/test_pyi.py
@@ -210,13 +210,17 @@ class PyiTestCase(unittest.TestCase):
         )
         self.checkFileOutput("defaults.pyi", stdout_lines=stdout_lines)
 
-    def test_top_level_attributes(self) -> None:
+    def test_attribute_values(self) -> None:
         stdout_lines = (
             "6:15: Y015 Top-level attribute must not have a default value",
             "7:15: Y015 Top-level attribute must not have a default value",
             "8:10: Y015 Top-level attribute must not have a default value",
             "9:10: Y015 Top-level attribute must not have a default value",
             "10:10: Y015 Top-level attribute must not have a default value",
+            '19:19: Y016 Instance attribute must not have a default value other than "..."',
+            '20:14: Y016 Instance attribute must not have a default value other than "..."',
+            '21:14: Y016 Instance attribute must not have a default value other than "..."',
+            '22:14: Y016 Instance attribute must not have a default value other than "..."',
         )
         self.checkFileOutput("attribute_annotations.pyi", stdout_lines=stdout_lines)
 


### PR DESCRIPTION
This PR add two new checks:

* Y015: Top-level attribute must not have a default value. (Closes: #21)
* Y016: Instance attribute must not have a default value other than "...".

When using type comments, this will only disallow `ast.Num` and `ast.Str` nodes to ensure that aliasing still works. When using variable annotations it will disallow all values (except ellipses for instance variables).